### PR TITLE
jwt is now signed with public/private key pair

### DIFF
--- a/src/main/kotlin/com/fdt/authservice/application/security/JWTAuthorizationFilter.kt
+++ b/src/main/kotlin/com/fdt/authservice/application/security/JWTAuthorizationFilter.kt
@@ -41,7 +41,7 @@ class JWTAuthorizationFilter : OncePerRequestFilter() {
 
     private fun validateToken(request: HttpServletRequest): Claims {
         val jwtToken = request.getHeader(HttpHeaders.AUTHORIZATION).replace(PREFIX, "")
-        return Jwts.parserBuilder().setSigningKey(TokenService.key).build().parseClaimsJws(jwtToken).body
+        return Jwts.parserBuilder().setSigningKey(TokenService.keyPair.public).build().parseClaimsJws(jwtToken).body
     }
 
     private fun existsJWTToken(request: HttpServletRequest, res: HttpServletResponse): Boolean {

--- a/src/main/kotlin/com/fdt/authservice/domain/service/TokenService.kt
+++ b/src/main/kotlin/com/fdt/authservice/domain/service/TokenService.kt
@@ -8,12 +8,13 @@ import io.jsonwebtoken.SignatureAlgorithm
 import io.jsonwebtoken.security.Keys
 import org.springframework.stereotype.Service
 import java.security.Key
+import java.security.KeyPair
 
 @Service
 class TokenService(private val tokenRepository: TokenRepository) {
 
     companion object {
-        val key: Key = Keys.secretKeyFor(SignatureAlgorithm.HS256)
+        val keyPair: KeyPair = Keys.keyPairFor(SignatureAlgorithm.RS256)
     }
 
     fun create(userId: Long): Token {
@@ -26,6 +27,6 @@ class TokenService(private val tokenRepository: TokenRepository) {
         return Jwts
                 .builder()
                 .setSubject(username)
-                .signWith(key).compact()
+                .signWith(keyPair.private).compact()
     }
 }

--- a/src/test/kotlin/com/fdt/authservice/domain/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/fdt/authservice/domain/service/AuthServiceTest.kt
@@ -7,7 +7,7 @@ import com.fdt.authservice.domain.exception.InvalidLoginCredential
 import com.fdt.authservice.domain.exception.InvalidPassword
 import com.fdt.authservice.domain.exception.InvalidUser
 import com.fdt.authservice.domain.repository.CredentialRepository
-import com.fdt.authservice.domain.service.TokenService.Companion.key
+import com.fdt.authservice.domain.service.TokenService.Companion.keyPair
 import io.jsonwebtoken.Jwts
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -107,5 +107,5 @@ class AuthServiceTest {
             LoginCredential(credential.email, "", credential.password)
 
     private fun getJwtSubject(token: Token) =
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token.token).body.subject
+            Jwts.parserBuilder().setSigningKey(keyPair.public).build().parseClaimsJws(token.token).body.subject
 }


### PR DESCRIPTION
[aca](https://github.com/jwtk/jjwt#creating-safe-keys) explican en la docu de la libreria jjwt como crear las asymetric keys y [aca](https://github.com/jwtk/jjwt#signing-key) como usarlas para firmar el token cuando se crea, [aca](https://github.com/jwtk/jjwt#verification-key) explican como usarlas para leer el token.

[En este post](https://blog.miguelgrinberg.com/post/json-web-tokens-with-public-key-signatures) explican porque esta bueno en una arquitectura de microservicios usar dos keys en lugar de una